### PR TITLE
fs: sdfat: __sdfat_submit_bio_write() should always submit a WRITE

### DIFF
--- a/fs/sdfat/sdfat.c
+++ b/fs/sdfat/sdfat.c
@@ -256,7 +256,7 @@ static inline void __sdfat_submit_bio_write(struct bio *bio,
 {
 	int write_flags = wbc_to_write_flags(wbc);
 
-	submit_bio(write_flags, bio);
+	submit_bio(WRITE | write_flags, bio);
 }
 
 static inline unsigned int __sdfat_full_name_hash(const struct dentry *unused, const char *name, unsigned int len)


### PR DESCRIPTION
sdfat version 2.4.5 introduced wbc_to_write_flags() as a compat
function for legacy kernels. Unfortunately, as the legacy
__sdfat_submit_bio_write() path was adapted to take advantage of
wbc_to_write_flags(), it used the return value direcly as the
rw paramater to submit_bio(), and the default return value is 0
(READ). This becomes a problem later when write paths assert that
bio_data_dir() is WRITE (i.e., write bit of bio->bi_rw is set).

Pass a bitwise-or of WRITE and the return value of wbc_to_write_flags()
to submit_bio() on this legacy path. This logically unifies the
approach with the newer path here and directly with the legacy path of
__sdfat_submit_bio_write2() in mpage.c.

Fixes: afd489c6a8c8 ("fs: sdfat: Update to version 2.4.5")
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>
Change-Id: Ic7b937a467e9e116c3390c6ac0e009a59229b93c